### PR TITLE
feat: 🎸 lazy conditionals

### DIFF
--- a/src/__tests__/__snapshots__/conditional.spec.ts.snap
+++ b/src/__tests__/__snapshots__/conditional.spec.ts.snap
@@ -91,6 +91,18 @@ subgraph cluster_0 {
 exports[`buildkite-graph Steps Command step addition dot 2`] = `
 "digraph \\"whatever\\" {
   graph [ compound =true ];
+subgraph cluster_0 {
+  graph [ color = \\"black\\" ];
+  \\"<yarn && yarn test>\\" [ color = \\"grey\\" ];
+}
+
+}
+"
+`;
+
+exports[`buildkite-graph Steps Command step addition dot 3`] = `
+"digraph \\"whatever\\" {
+  graph [ compound =true ];
 }
 "
 `;
@@ -110,6 +122,19 @@ Object {
 
 exports[`buildkite-graph Steps Command step addition json 2`] = `
 Object {
+  "steps": Array [
+    Object {
+      "command": Array [
+        "yarn",
+        "yarn test",
+      ],
+    },
+  ],
+}
+`;
+
+exports[`buildkite-graph Steps Command step addition json 3`] = `
+Object {
   "steps": Array [],
 }
 `;
@@ -123,6 +148,14 @@ exports[`buildkite-graph Steps Command step addition yaml 1`] = `
 `;
 
 exports[`buildkite-graph Steps Command step addition yaml 2`] = `
+"steps:
+  - command:
+      - yarn
+      - yarn test
+"
+`;
+
+exports[`buildkite-graph Steps Command step addition yaml 3`] = `
 "steps: []
 "
 `;

--- a/src/__tests__/conditional.spec.ts
+++ b/src/__tests__/conditional.spec.ts
@@ -1,9 +1,9 @@
-import { CommandStep, Conditional, Pipeline, Step } from '../';
+import { CommandStep, Conditional, Pipeline, Step, GeneratorFn } from '../';
 import { createTest } from './helpers';
 
-class MyConditional<T> extends Conditional<T> {
-    constructor(step: T, private readonly accepted: boolean) {
-        super(step);
+class MyConditional<T extends Pipeline | Step> extends Conditional<T> {
+    constructor(step: T | GeneratorFn<T>, private readonly accepted: boolean) {
+        super(step as any);
     }
 
     accept(): boolean {

--- a/src/__tests__/conditional.spec.ts
+++ b/src/__tests__/conditional.spec.ts
@@ -1,7 +1,7 @@
 import { CommandStep, Conditional, Pipeline, Step } from '../';
 import { createTest } from './helpers';
 
-class MyConditional<T extends Step | Pipeline> extends Conditional<T> {
+class MyConditional<T> extends Conditional<T> {
     constructor(step: T, private readonly accepted: boolean) {
         super(step);
     }
@@ -18,6 +18,12 @@ describe('buildkite-graph', () => {
                 new Pipeline('whatever').add(
                     new MyConditional(
                         new CommandStep('yarn').add('yarn test'),
+                        true,
+                    ),
+                ),
+                new Pipeline('whatever').add(
+                    new MyConditional(
+                        () => new CommandStep('yarn').add('yarn test'),
                         true,
                     ),
                 ),

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -1,7 +1,9 @@
-export abstract class Conditional<T> {
+import { Step, Pipeline, GeneratorFn } from '.';
+
+export abstract class Conditional<T extends Step | Pipeline> {
     constructor(guarded: T);
-    constructor(guarded: () => T);
-    constructor(private readonly guarded: T) {}
+    constructor(guarded: GeneratorFn<Pipeline | Step>);
+    constructor(private readonly guarded: T | GeneratorFn<T>) {}
 
     get(): T {
         return typeof this.guarded === 'function'

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -1,8 +1,12 @@
 export abstract class Conditional<T> {
+    constructor(guarded: T);
+    constructor(guarded: () => T);
     constructor(private readonly guarded: T) {}
 
     get(): T {
-        return this.guarded;
+        return typeof this.guarded === 'function'
+            ? this.guarded()
+            : this.guarded;
     }
 
     abstract accept(): boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,11 @@ export { Command, CommandStep } from './steps/command';
 export { Plugin } from './steps/command/plugins';
 export { TriggerStep } from './steps/trigger';
 
-export type PotentialStep = Step | Conditional<Step | Pipeline> | Pipeline;
+type StepGeneratorFn = () => Pipeline | Step;
+export type PotentialStep =
+    | Step
+    | Conditional<StepGeneratorFn | ReturnType<StepGeneratorFn>>
+    | Pipeline;
 
 @Exclude()
 export class Pipeline {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,8 @@ export { Command, CommandStep } from './steps/command';
 export { Plugin } from './steps/command/plugins';
 export { TriggerStep } from './steps/trigger';
 
-type StepGeneratorFn = () => Pipeline | Step;
-export type PotentialStep =
-    | Step
-    | Conditional<StepGeneratorFn | ReturnType<StepGeneratorFn>>
-    | Pipeline;
+export type GeneratorFn<T> = () => T;
+export type PotentialStep = Pipeline | Step | Conditional<Pipeline | Step>;
 
 @Exclude()
 export class Pipeline {


### PR DESCRIPTION
This adds a feature that allows conditionals to accept a generator
function for `<thing>` instead of `<thing>` itself. This generator function
is only called once `<thing>` is requested, allowing the code to generate
the conditional step or pipeline to be lazily evaluated.

Closes: #5