### PR TITLE
refactor: 💡 Changed Conditional from abstract class to interfac

### DIFF
--- a/examples/conditional.ts
+++ b/examples/conditional.ts
@@ -7,9 +7,14 @@ import { YamlSerializer } from '../src/serializers/yaml';
 /**
  * This Conditional will accept when there is at least one changed file ending in .feature
  */
-class FeatureFileChangedConditional<
-    T extends Pipeline | Step
-> extends Conditional<T> {
+class FeatureFileChangedConditional<T extends Pipeline | Step>
+    implements Conditional<T> {
+    constructor(private readonly step: T) {}
+
+    get() {
+        return this.step;
+    }
+
     accept() {
         const changedFiles = execSync(
             'git --no-pager diff master --name-only --no-renames',

--- a/src/__tests__/conditional.spec.ts
+++ b/src/__tests__/conditional.spec.ts
@@ -1,15 +1,20 @@
-import {
-    CommandStep,
-    Conditional,
-    Pipeline,
-    Step,
-    ThingOrGenerator,
-} from '../';
+import { CommandStep, Conditional, Generator, Pipeline, Step } from '../';
 import { createTest } from './helpers';
 
-class MyConditional<T extends Pipeline | Step> extends Conditional<T> {
+export type ThingOrGenerator<T> = T | Generator<T>;
+
+class MyConditional<T extends Pipeline | Step> implements Conditional<T> {
+    private readonly step?: T;
     constructor(step: ThingOrGenerator<T>, private readonly accepted: boolean) {
-        super(step as any);
+        if (typeof step === 'function') {
+            this.get = step;
+        } else {
+            this.step = step;
+        }
+    }
+
+    get(): T {
+        return this.step!;
     }
 
     accept(): boolean {

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -1,16 +1,8 @@
 import { Step, Pipeline } from '.';
 
 export type Generator<T> = () => T;
-export type ThingOrGenerator<T> = T | Generator<T>;
 
-export abstract class Conditional<T extends Step | Pipeline> {
-    constructor(private readonly guarded: ThingOrGenerator<T>) {}
-
-    get(): T {
-        return typeof this.guarded === 'function'
-            ? this.guarded()
-            : this.guarded;
-    }
-
-    abstract accept(): boolean;
+export interface Conditional<T extends Step | Pipeline> {
+    get(): T;
+    accept(): boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { KeyValue, KeyValueImpl, transformKeyValueImpl } from './key_value';
 import { WaitStep } from './steps/wait';
 import { stortedWithBlocks } from './stortedWithBlocks';
 export { ExitStatus, Step } from './base';
-export { Conditional, ThingOrGenerator, Generator } from './conditional';
+export { Conditional, Generator } from './conditional';
 export { BlockStep } from './steps/block';
 export { Option, SelectField, TextField } from './steps/block/fields';
 export { Command, CommandStep } from './steps/command';

--- a/src/unwrapSteps.ts
+++ b/src/unwrapSteps.ts
@@ -2,12 +2,25 @@ import { Pipeline, PotentialStep } from '.';
 import { Step } from './base';
 import { Conditional } from './conditional';
 
+function isConditional(x: PotentialStep): x is Conditional<any> {
+    return (
+        'get' in x &&
+        typeof x.get === 'function' &&
+        'accept' in x &&
+        typeof x.accept === 'function'
+    );
+}
+
+class UnknownPotentialStepError extends Error {}
+
 export function unwrapSteps(steps: PotentialStep[]): Step[] {
     const ret: Step[] = [];
     for (const s of steps) {
         if (s instanceof Pipeline) {
             ret.push(...unwrapSteps(s.steps));
-        } else if (s instanceof Conditional) {
+        } else if (s instanceof Step) {
+            ret.push(s);
+        } else if (isConditional(s)) {
             if (s.accept()) {
                 const cond = s.get();
                 if (cond instanceof Pipeline) {
@@ -17,7 +30,7 @@ export function unwrapSteps(steps: PotentialStep[]): Step[] {
                 }
             }
         } else {
-            ret.push(s);
+            throw new UnknownPotentialStepError(`Unknown potential step: ${s}`);
         }
     }
     return ret;


### PR DESCRIPTION
BREAKING CHANGE: abstract class Conditional -> interface Conditional

In https://github.com/joscha/buildkite-graph/commit/52b556032f3528c6b8c63db1d312aefc9e0baf3e#r34842809 @fa93hws suggested that the `Conditional` abstract class should actually be an interface to make it more flexible. This PR introduces this change. I am a bit unsure if it improves the usability of the package or not.