### PR TITLE
fix: 🐛 fixes the block step fields serialization

### DIFF
--- a/src/__tests__/__snapshots__/block.spec.ts.snap
+++ b/src/__tests__/__snapshots__/block.spec.ts.snap
@@ -168,8 +168,8 @@ Object {
           "default": "Flying Dolphin",
           "hint": "What’s the code name for this release? :name_badge:",
           "key": "release-name",
-          "label": "Code Name",
           "required": false,
+          "text": "Code Name",
         },
       ],
     },
@@ -187,7 +187,6 @@ Object {
           "default": "beta",
           "hint": "What’s the release stream?",
           "key": "release-stream",
-          "label": "Stream",
           "options": Array [
             Object {
               "label": "Beta",
@@ -199,6 +198,7 @@ Object {
             },
           ],
           "required": false,
+          "select": "Stream",
         },
       ],
     },
@@ -221,7 +221,6 @@ Object {
           ],
           "hint": "Which regions should we deploy this to? :earth_asia:",
           "key": "regions",
-          "label": "Regions",
           "multiple": true,
           "options": Array [
             Object {
@@ -241,6 +240,7 @@ Object {
               "value": "aunz",
             },
           ],
+          "select": "Regions",
         },
       ],
     },
@@ -264,9 +264,9 @@ exports[`buildkite-graph Steps Block with fields yaml 2`] = `
   - block: my title
     fields:
       - key: release-name
-        label: Code Name
         hint: 'What’s the code name for this release? :name_badge:'
         required: false
+        text: Code Name
         default: Flying Dolphin
 "
 `;
@@ -276,7 +276,6 @@ exports[`buildkite-graph Steps Block with fields yaml 3`] = `
   - block: my title
     fields:
       - key: release-stream
-        label: Stream
         hint: What’s the release stream?
         required: false
         options:
@@ -284,6 +283,7 @@ exports[`buildkite-graph Steps Block with fields yaml 3`] = `
             value: beta
           - label: Stable
             value: stable
+        select: Stream
         default: beta
 "
 `;
@@ -293,7 +293,6 @@ exports[`buildkite-graph Steps Block with fields yaml 4`] = `
   - block: my title
     fields:
       - key: regions
-        label: Regions
         hint: 'Which regions should we deploy this to? :earth_asia:'
         options:
           - label: North America
@@ -304,6 +303,7 @@ exports[`buildkite-graph Steps Block with fields yaml 4`] = `
             value: asia
           - label: Oceania
             value: aunz
+        select: Regions
         default:
           - na
           - eur

--- a/src/__tests__/__snapshots__/block.spec.ts.snap
+++ b/src/__tests__/__snapshots__/block.spec.ts.snap
@@ -144,13 +144,16 @@ Object {
       "fields": Array [
         Object {
           "key": "field-1",
+          "text": "Label 1",
         },
         Object {
           "key": "field-2",
           "options": Array [],
+          "select": "Label 2",
         },
         Object {
           "key": "field-3",
+          "text": "Label 3",
         },
       ],
     },
@@ -253,9 +256,12 @@ exports[`buildkite-graph Steps Block with fields yaml 1`] = `
   - block: my title
     fields:
       - key: field-1
+        text: Label 1
       - key: field-2
         options: []
+        select: Label 2
       - key: field-3
+        text: Label 3
 "
 `;
 

--- a/src/__tests__/block.spec.ts
+++ b/src/__tests__/block.spec.ts
@@ -28,9 +28,9 @@ describe('buildkite-graph', () => {
             createTest('with fields', () => [
                 new Pipeline('whatever').add(
                     new BlockStep('my title').fields
-                        .add(new TextField('field-1'))
-                        .fields.add(new SelectField('field-2'))
-                        .fields.add(new TextField('field-3')),
+                        .add(new TextField('field-1', 'Label 1'))
+                        .fields.add(new SelectField('field-2', 'Label 2'))
+                        .fields.add(new TextField('field-3', 'Label 3')),
                 ),
                 new Pipeline('whatever').add(
                     new BlockStep('my title').fields.add(

--- a/src/steps/block/fields.ts
+++ b/src/steps/block/fields.ts
@@ -7,7 +7,6 @@ abstract class Field {
     public readonly required?: false;
     constructor(
         public readonly key: string,
-        public readonly label?: string,
         public readonly hint?: string,
         required = false,
     ) {
@@ -20,15 +19,17 @@ abstract class Field {
 }
 @Expose()
 export class TextField extends Field {
+    private readonly text: string;
     private readonly default?: string;
     constructor(
         key: string,
-        label?: string,
+        label: string,
         hint?: string,
         required = true,
         defaultValue?: string,
     ) {
-        super(key, label, hint, required);
+        super(key, hint, required);
+        this.text = label;
         this.default = defaultValue;
     }
 }
@@ -43,12 +44,13 @@ export class Option {
 }
 @Expose()
 export class SelectField extends Field {
+    private readonly select: string;
     private options: Option[] = [];
     private readonly multiple?: true;
     private readonly default?: string | string[];
     constructor(
         key: string,
-        label?: string,
+        label: string,
         hint?: string,
         required?: boolean,
         multiple?: false,
@@ -56,7 +58,7 @@ export class SelectField extends Field {
     );
     constructor(
         key: string,
-        label?: string,
+        label: string,
         hint?: string,
         required?: boolean,
         multiple?: true,
@@ -64,13 +66,14 @@ export class SelectField extends Field {
     );
     constructor(
         key: string,
-        label?: string,
+        label: string,
         hint?: string,
         required = true,
         multiple = false,
         defaultValue?: string | string[],
     ) {
-        super(key, label, hint, required);
+        super(key, hint, required);
+        this.select = label;
         this.default = defaultValue;
         if (multiple) {
             this.multiple = multiple;


### PR DESCRIPTION
The fields had a 'label' attribute each, however they are expected to
have the label in an attribute based on their type, e.g. the "text"
field wants a property `text` which has a value of the given label. See
https://buildkite.com/docs/pipelines/block-step#text-input-attributes