### PR TITLE
feat: 🎸 isEffectOf (weak dependencies)

### DIFF
--- a/src/__tests__/__snapshots__/conditional.spec.ts.snap
+++ b/src/__tests__/__snapshots__/conditional.spec.ts.snap
@@ -233,6 +233,32 @@ exports[`buildkite-graph Steps Command async step creation yaml 2`] = `
 "
 `;
 
+exports[`buildkite-graph Steps Command isEffectOf effects of effects will be added if first effect dependency is accepted structure 1`] = `
+"* <run tests>
+* [wait]
+* <create coverage>
+* [wait]
+* <deploy coverage>"
+`;
+
+exports[`buildkite-graph Steps Command isEffectOf effects of effects will not be added if first effect dependency is rejected structure 1`] = `""`;
+
+exports[`buildkite-graph Steps Command isEffectOf last call wins structure 1`] = `
+"* <run tests>
+* [wait]
+* <deploy coverage>"
+`;
+
+exports[`buildkite-graph Steps Command isEffectOf last call wins structure 2`] = `""`;
+
+exports[`buildkite-graph Steps Command isEffectOf will add steps if their effect dependency is accepted structure 1`] = `
+"* <run tests>
+* [wait]
+* <deploy coverage>"
+`;
+
+exports[`buildkite-graph Steps Command isEffectOf will not add steps if effect dependency is rejected structure 1`] = `""`;
+
 exports[`buildkite-graph Steps Command step addition dot 1`] = `
 "digraph \\"whatever\\" {
   graph [ compound =true ];

--- a/src/sortedSteps.ts
+++ b/src/sortedSteps.ts
@@ -1,6 +1,6 @@
 import TopologicalSort from 'topological-sort';
 import { Step } from './base';
-import { Pipeline } from './index';
+import { Pipeline, PotentialStep } from './index';
 import { unwrapSteps } from './unwrapSteps';
 import { Conditional } from './conditional';
 
@@ -13,37 +13,45 @@ export async function sortedSteps(
         new Map(steps.map(step => [step, step])),
     );
 
+    async function getAndCacheDependency(
+        potentialDependency: PotentialStep,
+    ): Promise<Step> {
+        if (potentialDependency instanceof Conditional) {
+            if (cache.has(potentialDependency)) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                return cache.get(potentialDependency)!;
+            } else {
+                // in the case we have to unwrap the conditional we store it for later use
+                // otherwise the getter will be called many times, returning a new object each
+                // time which means evenm though multiple steps might depend on the same conditionals
+                // we would add a new step each time. Also, generating a step can be potentially expemnsive
+                // so we want to do this only once
+                const dependency = await potentialDependency.get();
+                cache.set(potentialDependency, dependency);
+                return dependency;
+            }
+        } else {
+            return potentialDependency;
+        }
+    }
+    const inGraph = (s: Step): boolean => steps.indexOf(s) !== -1;
+    const addToGraph = (s: Step): void => {
+        if (!inGraph(s)) {
+            // a dependency has not been added to the graph explicitly,
+            // so we add it implicitly
+            sortOp.addNode(s, s);
+            steps.push(s);
+            // maybe we want to rather throw here?
+            // Unsure...there could be a strict mode where we:
+            // throw new Error(`Step not part of the graph: '${dependency}'`);
+        }
+    };
+
+    const removedEffects: Step[] = [];
     for (let i = 0; i < steps.length; i++) {
         const step = steps[i];
-        for (const potentialDependency of step.dependencies) {
-            // when we depend on a conditional the acceptor of the conditional doesn't matter
-            // we need to always get it and add it to the graph
-            let dependency: Step;
-            if (potentialDependency instanceof Conditional) {
-                if (cache.has(potentialDependency)) {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    dependency = cache.get(potentialDependency)!;
-                } else {
-                    // in the case we have to unwrap the conditional we store it for later use
-                    // otherwise the getter will be called many times, returning a new object each
-                    // time which means evenm though multiple steps might depend on the same conditionals
-                    // we would add a new step each time. Also, generating a step can be potentially expemnsive
-                    // so we want to do this only once
-                    dependency = await potentialDependency.get();
-                    cache.set(potentialDependency, dependency);
-                }
-            } else {
-                dependency = potentialDependency;
-            }
-            if (steps.indexOf(dependency) === -1) {
-                // a dependency has not been added to the graph explicitly,
-                // so we add it implicitly
-                sortOp.addNode(dependency, dependency);
-                steps.push(dependency);
-                // maybe we want to rather throw here?
-                // Unsure...there could be a strict mode where we:
-                // throw new Error(`Step not part of the graph: '${dependency}'`);
-            }
+        const addDependency = (dependency: Step): void => {
+            addToGraph(dependency);
             if (dependency !== step) {
                 // not a self-reference, we just add the edge as usual
                 sortOp.addEdge(dependency, step);
@@ -54,7 +62,48 @@ export async function sortedSteps(
                     sortOp.addEdge(steps[i - 1], step);
                 }
             }
+        };
+
+        for (const potentialDependency of step.dependencies) {
+            // when we depend on a conditional the acceptor of the conditional doesn't matter
+            // we need to always get it and add it to the graph
+            const dependency = await getAndCacheDependency(potentialDependency);
+            addDependency(dependency);
+        }
+
+        for (const potentialEffectDependency of step.effectDependencies) {
+            const dependency = await getAndCacheDependency(
+                potentialEffectDependency,
+            );
+            if (potentialEffectDependency instanceof Conditional) {
+                // in case it is a conditional we are interested in whether it that one was accepted or not
+                if (
+                    (await potentialEffectDependency.accept()) &&
+                    inGraph(dependency)
+                ) {
+                    // if it was accepted and it is part of the graph, add the dependency to the current step
+                    addDependency(dependency);
+                    step.dependsOn(potentialEffectDependency);
+                } else {
+                    // remove the current step from the graph
+                    removedEffects.push(step);
+                }
+            } else {
+                // the dependency is a step and it wasn't removed before;
+                // add ourselves to the graph if the step is part of the graph
+                if (
+                    inGraph(dependency) &&
+                    !removedEffects.includes(dependency)
+                ) {
+                    addDependency(dependency);
+                    step.dependsOn(potentialEffectDependency);
+                } else {
+                    removedEffects.push(step);
+                }
+            }
         }
     }
-    return Array.from(sortOp.sort().values()).map(i => i.node);
+    return Array.from(sortOp.sort().values())
+        .map(i => i.node)
+        .filter(s => !removedEffects.includes(s));
 }


### PR DESCRIPTION
Sometimes steps are only an effect of another; for example the
deployment of code coverage is only an effect of running the unit tests

Even though we add both steps to the pipeline, we really only expect
that the coverage step is executed if the test step is executed as well.
`isEffectOf` makes that possible, it allows you to specify a step as a
dependency without marking it as required (a weak dependency so to say).

Effectively this lets you do:
```st
deployCoverageStep.isEffectOf(testStepConditional)
pipeline.add(testStepConditional, deployCoverageStep);
```

and only if `testStepConditional`'s `.accept` returns `true`, the `deployCoverageStep` will be part of the graph.

Closes: #29