### PR TITLE
Add filter() method to Plugins<T> interface

### DIFF
--- a/src/__tests__/__snapshots__/command.spec.ts.snap
+++ b/src/__tests__/__snapshots__/command.spec.ts.snap
@@ -1039,7 +1039,7 @@ exports[`buildkite-graph Steps Command parallelism yaml_depends_on 2`] = `
 "
 `;
 
-exports[`buildkite-graph Steps Command plugins dot 1`] = `
+exports[`buildkite-graph Steps Command plugins add plugins dot 1`] = `
 "digraph \\"whatever\\" {
   graph [ compound =true ];
 subgraph cluster_0 {
@@ -1051,7 +1051,7 @@ subgraph cluster_0 {
 "
 `;
 
-exports[`buildkite-graph Steps Command plugins json 1`] = `
+exports[`buildkite-graph Steps Command plugins add plugins json 1`] = `
 Object {
   "steps": Array [
     Object {
@@ -1077,7 +1077,7 @@ Object {
 }
 `;
 
-exports[`buildkite-graph Steps Command plugins json_depends_on 1`] = `
+exports[`buildkite-graph Steps Command plugins add plugins json_depends_on 1`] = `
 Object {
   "steps": Array [
     Object {
@@ -1104,9 +1104,9 @@ Object {
 }
 `;
 
-exports[`buildkite-graph Steps Command plugins structure 1`] = `"* <noop>"`;
+exports[`buildkite-graph Steps Command plugins add plugins structure 1`] = `"* <noop>"`;
 
-exports[`buildkite-graph Steps Command plugins yaml 1`] = `
+exports[`buildkite-graph Steps Command plugins add plugins yaml 1`] = `
 "steps:
   - command: noop
     plugins:
@@ -1119,7 +1119,7 @@ exports[`buildkite-graph Steps Command plugins yaml 1`] = `
 "
 `;
 
-exports[`buildkite-graph Steps Command plugins yaml_depends_on 1`] = `
+exports[`buildkite-graph Steps Command plugins add plugins yaml_depends_on 1`] = `
 "steps:
   - key: _0
     command: noop

--- a/src/__tests__/command.spec.ts
+++ b/src/__tests__/command.spec.ts
@@ -220,48 +220,35 @@ describe('buildkite-graph', () => {
             ]);
 
             describe('plugins', () => {
-                const plugins = [
-                    new Plugin('bugcrowd/test-summary#v1.5.0', {
-                        inputs: [
-                            {
-                                label: ':htmllint: HTML lint',
-                                artifact_path: 'web/target/htmllint-*.txt',
-                                type: 'oneline',
-                            },
-                        ],
-                    }),
-                    new Plugin('detect-clowns#v1.0.0'),
-                ];
-                const stepWithPlugins = new CommandStep('noop').plugins
-                    .add(plugins[0])
-                    .plugins.add(plugins[1]);
+                let plugins: Plugin[];
+                let stepWithPlugins: CommandStep;
+
+                beforeEach(() => {
+                    plugins = [
+                        new Plugin('bugcrowd/test-summary#v1.5.0', {
+                            inputs: [
+                                {
+                                    label: ':htmllint: HTML lint',
+                                    artifact_path: 'web/target/htmllint-*.txt',
+                                    type: 'oneline',
+                                },
+                            ],
+                        }),
+                        new Plugin('detect-clowns#v1.0.0'),
+                    ];
+                    stepWithPlugins = new CommandStep('noop').plugins
+                        .add(plugins[0])
+                        .plugins.add(plugins[1]);
+                });
 
                 createTest('add plugins', () =>
                     new Pipeline('whatever').add(stepWithPlugins),
                 );
 
-                it.each([
-                    {
-                        predicate: (plugin: Plugin) =>
-                            plugin.pluginNameOrPath.includes('bugcrowd'),
-                        expected: [plugins[0]],
-                    },
-                    {
-                        predicate: (plugin: Plugin) =>
-                            plugin.pluginNameOrPath.includes('.0'),
-                        expected: plugins,
-                    },
-                    {
-                        predicate: (plugin: Plugin) =>
-                            plugin.pluginNameOrPath.includes(
-                                'NONEXISTENT_NAME',
-                            ),
-                        expected: [],
-                    },
-                ])('filter plugins', ({ predicate, expected }) => {
+                it('is possible to query existing plugins', () => {
                     expect(
-                        stepWithPlugins.plugins.filter(predicate),
-                    ).toMatchObject(expected);
+                        stepWithPlugins.plugins.filter(() => true),
+                    ).toMatchObject(plugins);
                 });
             });
 

--- a/src/__tests__/command.spec.ts
+++ b/src/__tests__/command.spec.ts
@@ -244,19 +244,24 @@ describe('buildkite-graph', () => {
                     {
                         predicate: (plugin: Plugin) =>
                             plugin.pluginNameOrPath.includes('bugcrowd'),
-                        expected: plugins[0],
+                        expected: [plugins[0]],
+                    },
+                    {
+                        predicate: (plugin: Plugin) =>
+                            plugin.pluginNameOrPath.includes('.0'),
+                        expected: plugins,
                     },
                     {
                         predicate: (plugin: Plugin) =>
                             plugin.pluginNameOrPath.includes(
                                 'NONEXISTENT_NAME',
                             ),
-                        expected: undefined,
+                        expected: [],
                     },
-                ])('get plugins', ({ predicate, expected }) => {
-                    expect(stepWithPlugins.plugins.get(predicate)).toBe(
-                        expected,
-                    );
+                ])('filter plugins', ({ predicate, expected }) => {
+                    expect(
+                        stepWithPlugins.plugins.filter(predicate),
+                    ).toMatchObject(expected);
                 });
             });
 

--- a/src/steps/command/plugins.ts
+++ b/src/steps/command/plugins.ts
@@ -13,7 +13,7 @@ export class Plugin {
 export interface Plugins<T> {
     add(plugin: Plugin): T;
     /** Return a list of plugins that match the given predicate */
-    filter(predicate: (plugin: Plugin) => boolean): Plugin[];
+    filter: Plugin[]['filter'];
 }
 
 export function transformPlugins(value: PluginsImpl<any>): object | undefined {
@@ -36,7 +36,9 @@ export class PluginsImpl<T> extends Chainable<T> implements Plugins<T> {
         return this.parent;
     }
 
-    filter(predicate: (plugin: Plugin) => boolean): Plugin[] {
-        return this.plugins.filter(predicate);
+    filter(
+        ...args: Parameters<Plugins<T>['filter']>
+    ): ReturnType<Plugins<T>['filter']> {
+        return this.plugins.filter(...args);
     }
 }

--- a/src/steps/command/plugins.ts
+++ b/src/steps/command/plugins.ts
@@ -12,6 +12,8 @@ export class Plugin {
 
 export interface Plugins<T> {
     add(plugin: Plugin): T;
+    /** Get the first plugin that matches the given predicate */
+    get(predicate: (plugin: Plugin) => boolean): Plugin | undefined;
 }
 
 export function transformPlugins(value: PluginsImpl<any>): object | undefined {
@@ -32,5 +34,9 @@ export class PluginsImpl<T> extends Chainable<T> implements Plugins<T> {
     add(plugin: Plugin): T {
         this.plugins.push(plugin);
         return this.parent;
+    }
+    
+    get(predicate: (plugin: Plugin) => boolean): Plugin | undefined {
+        return this.plugins.find(predicate);
     }
 }

--- a/src/steps/command/plugins.ts
+++ b/src/steps/command/plugins.ts
@@ -12,8 +12,8 @@ export class Plugin {
 
 export interface Plugins<T> {
     add(plugin: Plugin): T;
-    /** Get the first plugin that matches the given predicate */
-    get(predicate: (plugin: Plugin) => boolean): Plugin | undefined;
+    /** Return a list of plugins that match the given predicate */
+    filter(predicate: (plugin: Plugin) => boolean): Plugin[];
 }
 
 export function transformPlugins(value: PluginsImpl<any>): object | undefined {
@@ -35,8 +35,8 @@ export class PluginsImpl<T> extends Chainable<T> implements Plugins<T> {
         this.plugins.push(plugin);
         return this.parent;
     }
-    
-    get(predicate: (plugin: Plugin) => boolean): Plugin | undefined {
-        return this.plugins.find(predicate);
+
+    filter(predicate: (plugin: Plugin) => boolean): Plugin[] {
+        return this.plugins.filter(predicate);
     }
 }


### PR DESCRIPTION
## In this PR
- Added a `filter()` method to `interface Plugins<T>`.

## Background
Currently once a plugin has been added to `Plugins` there is no way to find it later. This can cause a problem with accidentally doubling up on adding a plugin conditionally.

## Details
Implemented `filter()` with a simple `this.plugins.filter()` in `PluginsImpl`.

Added tests for `filter()`ing plugins.

One other option was to add a public `plugins: Plugin[]` array to the interface. This is shown in #47.

### Expected use
```ts
const step = new CommandStep('name');
step
    .plugins.add(new Plugin('plugin1'))
    .plugins.add(new Plugin('plugin2'))

const foundPlugins = step.plugins.filter(plugin => plugin.pluginNameOrPath.includes('2'))
// foundPlugins = [plugin2]
```