### PR TITLE
Add a public `plugins` array to the `Plugins<T>` interface

### DIFF
--- a/src/steps/command/plugins.ts
+++ b/src/steps/command/plugins.ts
@@ -11,6 +11,7 @@ export class Plugin {
 }
 
 export interface Plugins<T> {
+    readonly plugins: Plugin[];
     add(plugin: Plugin): T;
 }
 


### PR DESCRIPTION
## In this PR
- Added `readonly plugins: Plugin[]` prop to `interface Plugins<T>`.

## Background
Currently once a plugin has been added to `Plugins` there is no way to find it later. This can cause a problem with accidentally doubling up on adding a plugin conditionally.

This is an alternative approach to #46 to solving this problem.

## Details
The `PluginsImpl` class already had a `public plugins: Plugin[]` member so no other changes were necessary.

The usefulness of the existing `add()` method is diminished now since devs can use array methods like `.push()` directly. `add()` will return the parent object for chaining which may still be useful, but `plugins.push(...plugins)` can now achieve a very similar result.

Using the new `plugins` prop is also now a bit obtuse (`step.plugins.plugins`), as seen in the below example.

### Expected use
```ts
const step = new CommandStep('name');
step
    .plugins.add(new Plugin('plugin1'))
    .plugins.add(new Plugin('plugin2'))

const foundPlugin = step.plugins.plugins.find(plugin => plugin.pluginNameOrPath.includes('2'))
// foundPlugin = plugin2
```