### PR TITLE
Disallow key longer than 100 chars

### DIFF
--- a/src/__tests__/command.spec.ts
+++ b/src/__tests__/command.spec.ts
@@ -90,11 +90,7 @@ describe('buildkite-graph', () => {
                     .dependsOn(a)
                     .alwaysExecute()
                     .allowDependencyFailure();
-                return new Pipeline('test')
-                    .add(a)
-                    .add(b)
-                    .add(c)
-                    .add(d);
+                return new Pipeline('test').add(a).add(b).add(c).add(d);
             });
 
             describe('timeouts', () => {
@@ -369,6 +365,18 @@ describe('buildkite-graph', () => {
                             .automatic(new Map([[-1, 3]]))
                             .retry.getAutomaticValue(),
                     ).toEqual(new Map([[-1, 3]]));
+                });
+            });
+
+            describe('edge cases', () => {
+                it('throws if key is empty', () => {
+                    expect(() => new CommandStep('noop').withKey('')).toThrow();
+                });
+
+                it('throws if key is longer than 100 chars', () => {
+                    expect(() =>
+                        new CommandStep('noop').withKey('a'.repeat(101)),
+                    ).toThrow();
                 });
             });
         });

--- a/src/base.ts
+++ b/src/base.ts
@@ -52,7 +52,7 @@ export abstract class Step implements BaseStep, Serializable {
     }
 
     withKey(identifier: string): this {
-        ow(identifier, ow.string.nonEmpty);
+        ow(identifier, ow.string.nonEmpty.maxLength(100));
         this._key = identifier;
         return this;
     }
@@ -85,7 +85,7 @@ export abstract class Step implements BaseStep, Serializable {
 
     isEffectOf(...steps: PotentialStep[]): this {
         this.assertEffectOrDependency(...steps);
-        steps.forEach(s => {
+        steps.forEach((s) => {
             this.effectDependencies.add(s);
             this.dependencies.delete(s);
         });
@@ -111,7 +111,7 @@ export abstract class Step implements BaseStep, Serializable {
                     [...this.dependencies, ...this.effectDependencies],
                     opts.cache,
                 )
-            ).map(s => ({
+            ).map((s) => ({
                 /* eslint-disable @typescript-eslint/camelcase */
                 step: s.key,
                 allow_failure: this._allowDependencyFailure


### PR DESCRIPTION
Buildkite seems not to be happy with key longer than 100 chars

> 2021-04-30 01:22:54 FATAL  Failed to upload and process pipeline: POST https://agent.buildkite.com/v3/jobs/<some_id>/pipelines: 422 One of the steps you provided was invalid: Step keys can have a maximum of 100 characters