### PR TITLE
use serialize method in transform command

### DIFF
--- a/src/steps/command.ts
+++ b/src/steps/command.ts
@@ -28,7 +28,8 @@ function assertSkipValue(value: SkipValue): void {
 type SkipValue = boolean | string;
 export type SkipFunction = () => SkipValue;
 
-let transformCommandKey = Symbol();
+// TODO: remove cast when https://github.com/microsoft/TypeScript/pull/44512 landed
+const transformCommandKey: string = Symbol('transformCommand') as any;
 export class Command {
     constructor(public command: string, public timeout: number = Infinity) {
         ow(command, ow.string);
@@ -246,7 +247,7 @@ export class CommandStep extends LabeledStep {
         /* eslint-disable @typescript-eslint/camelcase */
         return {
             ...(await super.toJson(opts)),
-            command: Command.transformCommand(this.command),
+            command: Command[transformCommandKey](this.command),
             env,
             parallelism: this.parallelism,
             concurrency: this.concurrency,

--- a/src/steps/command.ts
+++ b/src/steps/command.ts
@@ -28,22 +28,22 @@ function assertSkipValue(value: SkipValue): void {
 type SkipValue = boolean | string;
 export type SkipFunction = () => SkipValue;
 
-// TODO: remove cast when https://github.com/microsoft/TypeScript/pull/44512 landed
-const transformCommandKey: string = Symbol('transformCommand') as any;
+const transformCommandKey: unique symbol = Symbol('transformCommand');
 export class Command {
+    private static [transformCommandKey] = (
+        value: Command[],
+    ): undefined | string | string[] => {
+        if (!value || value.length === 0) {
+            return undefined;
+        }
+        return value.length === 1
+            ? value[0].serialize()
+            : value.map((c) => c.serialize());
+    };
+
     constructor(public command: string, public timeout: number = Infinity) {
         ow(command, ow.string);
         assertTimeout(timeout);
-        this[transformCommandKey] = (
-            value: Command[],
-        ): undefined | string | string[] => {
-            if (!value || value.length === 0) {
-                return undefined;
-            }
-            return value.length === 1
-                ? value[0].serialize()
-                : value.map((c) => c.serialize());
-        };
     }
 
     toString(): string {

--- a/src/steps/command.ts
+++ b/src/steps/command.ts
@@ -28,10 +28,21 @@ function assertSkipValue(value: SkipValue): void {
 type SkipValue = boolean | string;
 export type SkipFunction = () => SkipValue;
 
+let transformCommandKey = Symbol();
 export class Command {
     constructor(public command: string, public timeout: number = Infinity) {
         ow(command, ow.string);
         assertTimeout(timeout);
+        this[transformCommandKey] = (
+            value: Command[],
+        ): undefined | string | string[] => {
+            if (!value || value.length === 0) {
+                return undefined;
+            }
+            return value.length === 1
+                ? value[0].serialize()
+                : value.map((c) => c.serialize());
+        };
     }
 
     toString(): string {
@@ -40,15 +51,6 @@ export class Command {
 
     protected serialize(): string {
         return this.toString();
-    }
-
-    static transformCommand(value: Command[]): undefined | string | string[] {
-        if (!value || value.length === 0) {
-            return undefined;
-        }
-        return value.length === 1
-            ? value[0].serialize()
-            : value.map((c) => c.serialize());
     }
 }
 

--- a/src/steps/command.ts
+++ b/src/steps/command.ts
@@ -38,21 +38,21 @@ export class Command {
         return this.command;
     }
 
-    serialize(): string {
+    protected serialize(): string {
         return this.toString();
+    }
+
+    static transformCommand(value: Command[]): undefined | string | string[] {
+        if (!value || value.length === 0) {
+            return undefined;
+        }
+        return value.length === 1
+            ? value[0].serialize()
+            : value.map((c) => c.serialize());
     }
 }
 
 type Agents = Map<string, string>;
-
-const transformCommand = (value: Command[]): undefined | string | string[] => {
-    if (!value || value.length === 0) {
-        return undefined;
-    }
-    return value.length === 1
-        ? value[0].serialize()
-        : value.map((c) => c.serialize());
-};
 
 const transformSoftFail = (
     value: Set<ExitStatus>,
@@ -244,7 +244,7 @@ export class CommandStep extends LabeledStep {
         /* eslint-disable @typescript-eslint/camelcase */
         return {
             ...(await super.toJson(opts)),
-            command: transformCommand(this.command),
+            command: Command.transformCommand(this.command),
             env,
             parallelism: this.parallelism,
             concurrency: this.concurrency,

--- a/src/steps/command.ts
+++ b/src/steps/command.ts
@@ -37,6 +37,10 @@ export class Command {
     toString(): string {
         return this.command;
     }
+
+    serialize(): string {
+        return this.toString();
+    }
 }
 
 type Agents = Map<string, string>;
@@ -45,7 +49,9 @@ const transformCommand = (value: Command[]): undefined | string | string[] => {
     if (!value || value.length === 0) {
         return undefined;
     }
-    return value.length === 1 ? value[0].command : value.map((c) => c.command);
+    return value.length === 1
+        ? value[0].serialize()
+        : value.map((c) => c.serialize());
 };
 
 const transformSoftFail = (


### PR DESCRIPTION
This is small change, but the intention is to add a serialize member function that is called when transforming commands into their serialized counterparts.

The intention is when we add a meta-command we can add it as a subclass of `Command` and override `serialize` to add in the path to the wrapper script.