### PR TITLE
fix: import from "src"

### DIFF
--- a/src/steps/block.ts
+++ b/src/steps/block.ts
@@ -1,7 +1,7 @@
 import ow from 'ow';
 import { BranchLimitedStep } from '../base';
 import { Fields, FieldsImpl } from './block/fields';
-import { ToJsonSerializationOptions } from 'src';
+import type { ToJsonSerializationOptions } from '../index';
 
 export class BlockStep extends BranchLimitedStep {
   private readonly title: string;

--- a/src/steps/command.ts
+++ b/src/steps/command.ts
@@ -13,7 +13,7 @@ import {
   mapToObject,
 } from '../base';
 import { Retry, RetryImpl } from './command/retry';
-import { ToJsonSerializationOptions } from 'src';
+import type { ToJsonSerializationOptions } from '../index';
 
 function assertTimeout(timeout: number): void {
   ow(timeout, ow.number.integerOrInfinite.positive);


### PR DESCRIPTION
otherwise yields

```
node_modules/buildkite-graph/dist/steps/block.d.ts:3:44 - error TS2307: Cannot find module 'src' or its corresponding type declarations.
3 import { ToJsonSerializationOptions } from 'src';
                                             ~~~~~
node_modules/buildkite-graph/dist/steps/command.d.ts:5:44 - error TS2307: Cannot find module 'src' or its corresponding type declarations.
5 import { ToJsonSerializationOptions } from 'src';
                                             ~~~~~
```
unless `skipLibCheck` is set to `true`.

cc @danjuv 