### PR TITLE
make serialize method public

### DIFF
--- a/examples/retry_command.ts
+++ b/examples/retry_command.ts
@@ -6,7 +6,7 @@ class RetryCommand extends Command {
     super(command.toString(), command.timeout * (retries + 1));
   }
 
-  protected serialize(): string {
+  public serialize(): string {
     return new Array(this.retries + 1).fill(this.command).join(' || ');
   }
 

--- a/src/steps/command.ts
+++ b/src/steps/command.ts
@@ -50,7 +50,7 @@ export class Command {
     return this.command;
   }
 
-  protected serialize(): string {
+  public serialize(): string {
     return this.toString();
   }
 }


### PR DESCRIPTION
Trying to serialize a function parameter of type `Command` returns:

```
error TS2446: Property 'serialize' is protected and only accessible through an instance of class 'RetryCommand'. This is an instance of class 'Command'.
```